### PR TITLE
Add PostgreSQL backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Name             | Type   | Description                                         
 `forward-user`   | String | Optional dedicated local user for the forward (two-user split). When set, queue mail is delivered to both the RT `user` (feeds rt-mailgate) and this user (forwards a copy to `forward-email`), so RT processing and the off-box copy don't interfere. Requires `forward-email`. | nil
 `logo`           | Hash   | Optional custom branding. `url` is fetched into RT's static images dir and `$LogoURL` is set to the served path; `link`/`alt` set `$LogoLinkURL`/`$LogoAltText`. Assumes the default (empty) `WebPath`; override `$LogoURL` via `extra-config` otherwise. | nil
 `internal-domain`| String | A workaround required needs a non-sublevel domain name to access the site internally | `rtlocal`
-`db.type`        | String | The database type, MySQL or Postgres                         | `mysql`
+`db.type`        | String | The database engine, passed to RT as `$DatabaseType`. Use `mysql` for MySQL/MariaDB or `Pg` for PostgreSQL. With `Pg` the cookbook installs the `perl-DBD-Pg` driver and the `psql` client (used by the one-time DB guards) instead of the MariaDB client. | `mysql`
 `db.host`        | String | The hostname of the DB server                                | `localhost`
 `db.name`        | String | The DB name on the DB server                                 | `rt`
 `db-upgrade`     | String | Opt-in: the RT version the database is currently at (e.g. `"4.4.7"`), passed as `--upgrade-from` to apply pending schema upgrades (after importing a DB or an RT package upgrade). The "proceed?" prompt is auto-confirmed, so **back up first**. See [docs/migration.md](docs/migration.md). | unset |

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -32,6 +32,12 @@ suites:
       - recipe[osl-rt-test::two_domain]
     provisioner:
       flavor_ref: 'c2.local.8c8m50d'
+  # Same as the default suite but with a PostgreSQL backend (db.type = Pg).
+  - name: postgresql
+    run_list:
+      - recipe[osl-rt-test::osl_request_tracker_postgresql]
+    provisioner:
+      flavor_ref: 'c2.local.8c8m50d'
   # Imports a pre-seeded older-RT database (test/cookbooks/osl-rt-test/files/rt-seed.sql.gz,
   # not committed -- see docs/migration.md) and exercises the db-upgrade path.
   - name: migration

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -13,6 +13,12 @@ module OslRT
         node['platform_version'].to_i >= 10
       end
 
+      # True when the configured database engine is PostgreSQL. RT expects the
+      # literal 'Pg' for $DatabaseType; anything else (default 'mysql') is MySQL.
+      def osl_rt_pg?(rt_config)
+        rt_config['db']['type'] == 'Pg'
+      end
+
       # Initalize the default configurations
       def osl_rt_load_config_defaults
         {
@@ -117,11 +123,48 @@ module OslRT
         [rt_config['fqdn'], osl_rt_mail_domain(rt_config)].uniq
       end
 
-      # Shell guard (for not_if/only_if) that succeeds when the SQL returns a row,
-      # so one-time DB/queue steps key off real DB state and skip an imported DB.
-      def osl_rt_mysql_guard(rt_config, query)
-        "mysql -u #{rt_config['db-username']} -p#{rt_config['db-password']} " \
-          "-N -B -e \"#{query}\" #{rt_config['db']['name']} 2>/dev/null | grep -q ."
+      # Shell guard (for not_if/only_if) that succeeds when the SQL SELECT returns
+      # a row, so one-time DB/queue steps key off real DB state and skip an
+      # imported DB. Dispatches to the client for the configured engine.
+      def osl_rt_db_guard(rt_config, query)
+        if osl_rt_pg?(rt_config)
+          "PGPASSWORD='#{rt_config['db-password']}' psql -h #{rt_config['db']['host']} " \
+            "-U #{rt_config['db-username']} -tAc \"#{query}\" #{rt_config['db']['name']} 2>/dev/null | grep -q ."
+        else
+          "mysql -u #{rt_config['db-username']} -p#{rt_config['db-password']} " \
+            "-N -B -e \"#{query}\" #{rt_config['db']['name']} 2>/dev/null | grep -q ."
+        end
+      end
+
+      # Query that yields a row only once RT's schema has been loaded, used to
+      # skip DB init (and the root-password set) against an already-populated
+      # database. MySQL uses SHOW TABLES; Postgres folds the unquoted table name
+      # to lowercase, so to_regclass('users') is non-null once the table exists.
+      def osl_rt_schema_present_query(rt_config)
+        osl_rt_pg?(rt_config) ? "SELECT to_regclass('users')" : "SHOW TABLES LIKE 'Users'"
+      end
+
+      # Command to set RT's root password directly in the DB, fired only on a
+      # fresh init (never on import). RT accepts a bare MD5 hash, which both
+      # engines' md5() function produces over the cleartext password.
+      def osl_rt_set_root_password_command(rt_config)
+        if osl_rt_pg?(rt_config)
+          <<~EOC
+            PGPASSWORD='#{rt_config['db-password']}' psql -h #{rt_config['db']['host']} \
+              -U #{rt_config['db-username']} \
+              -c "UPDATE Users SET Password=md5('#{rt_config['root-password']}') WHERE Name='root';" \
+              #{rt_config['db']['name']}
+          EOC
+        else
+          <<~EOC
+            mysql -u #{rt_config['db-username']} \
+              -p#{rt_config['db-password']} \
+              -e 'UPDATE Users \
+                SET Password=md5("#{rt_config['root-password']}") \
+                WHERE Name="root";' \
+              #{rt_config['db']['name']}
+          EOC
+        end
       end
 
       # The plugin list to load, dropping any that ship in core on RT 5 (EL10+).

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ version           '2.1.0'
 
 depends           'osl-apache'
 depends           'osl-mysql'
+depends           'osl-postgresql'
 depends           'osl-postfix'
 depends           'yum-osuosl'
 depends           'perl', '~> 1.2.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,19 +32,29 @@ node.default['postfix']['access']['140.211.166.136'] = 'OK' # smtp3.osuosl.org
 node.default['postfix']['access']['140.211.166.137'] = 'OK' # smtp4.osuosl.org
 node.default['postfix']['access']['140.211.166.138'] = 'OK' # smtp1.osuosl.org
 
+# Initalize the attributes, and overwrite the defaults. Loaded up front so the
+# DB-engine-specific setup below (client packages, DB guards) can branch on the
+# configured database type.
+rt_config = osl_rt_load_config_defaults
+
+rt_config = rt_config.merge(data_bag_item('request-tracker', node['osl-rt']['data-bag'])) { |_key, _old_value, new_value| new_value }
+
 include_recipe 'osl-apache'
 include_recipe 'osl-apache::mod_remoteip'
 include_recipe 'osl-apache::mod_perl'
-include_recipe 'osl-mysql::client'
 include_recipe 'yum-osuosl'
 include_recipe 'perl'
 
 package %w(request-tracker mutt procmail)
 
-# Initalize the attributes, and overwrite the defaults
-rt_config = osl_rt_load_config_defaults
-
-rt_config = rt_config.merge(data_bag_item('request-tracker', node['osl-rt']['data-bag'])) { |_key, _old_value, new_value| new_value }
+# Database client + Perl DBD driver for the configured engine. Postgres needs
+# DBD::Pg and the psql client (used by the DB guards below); MySQL pulls in the
+# mariadb client and DBD::MySQL via osl-mysql::client.
+if osl_rt_pg?(rt_config)
+  package %w(perl-DBD-Pg postgresql)
+else
+  include_recipe 'osl-mysql::client'
+end
 
 # Public email domain (defaults to the host fqdn). Mail may be delivered to
 # either the fqdn or the public domain, so build a list of both for matching.
@@ -142,21 +152,14 @@ execute 'init-db-rt' do
       --dba-password #{rt_config['db-password']} \
       --skip-create
   EOC
-  not_if osl_rt_mysql_guard(rt_config, "SHOW TABLES LIKE 'Users'")
+  not_if osl_rt_db_guard(rt_config, osl_rt_schema_present_query(rt_config))
   sensitive true
   notifies :run, 'execute[Set root password]', :immediately
 end
 
 # Set the root password only on a fresh init (notified above), never on import.
 execute 'Set root password' do
-  command <<~EOC
-    mysql -u #{rt_config['db-username']} \
-      -p#{rt_config['db-password']} \
-      -e 'UPDATE Users \
-        SET Password=md5("#{rt_config['root-password']}") \
-        WHERE Name="root";' \
-      #{rt_config['db']['name']}
-  EOC
+  command osl_rt_set_root_password_command(rt_config)
   action :nothing
   sensitive true
 end
@@ -210,7 +213,7 @@ rt_config['queues'].each do |pt, email|
       name="#{pt}" correspondaddress="#{email}@#{mail_domain}" \
       commentaddress="#{email}-comment@#{mail_domain}"
     EOC
-    not_if osl_rt_mysql_guard(rt_config, "SELECT 1 FROM Queues WHERE Name='#{pt}'")
+    not_if osl_rt_db_guard(rt_config, "SELECT 1 FROM Queues WHERE Name='#{pt}'")
     sensitive true
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -467,4 +467,55 @@ describe 'osl-rt::default' do
     it { is_expected.to render_file('/etc/aliases').with_content('support: support') }
     it { is_expected.to render_file('/etc/aliases').with_content('imported: support') }
   end
+
+  # PostgreSQL backend (db.type = Pg): DBD::Pg + psql client instead of the
+  # mariadb client, and the DB guards/commands use psql.
+  context 'with a postgresql backend' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(ALMA_9) do |node|
+        node.default['osl-rt']['data-bag'] = 'default'
+      end.converge(described_recipe)
+    end
+
+    before do
+      stub_command('/usr/bin/test /etc/alternatives/mta -ef /usr/sbin/sendmail.postfix').and_return(true)
+      # Fresh DB so the one-time DB/queue setup runs (Postgres guards use psql).
+      stub_command(/to_regclass/).and_return(false)
+      stub_command(/SELECT 1 FROM Queues WHERE Name=/).and_return(false)
+      stub_data_bag_item('request-tracker', 'default').and_return({
+                                                                    'db': {
+                                                                      'type': 'Pg',
+                                                                      'host': 'localhost',
+                                                                      'name': 'rt',
+                                                                    },
+                                                                    'db-username': 'rt-user',
+                                                                    'db-password': 'rt-password',
+                                                                    'root-password': 'my-epic-rt',
+                                                                    'user': 'support',
+                                                                    'queues': {
+                                                                      'Support': 'support',
+                                                                    },
+                                                                  })
+    end
+
+    # Postgres pulls in the Perl driver + psql client, not the mariadb client.
+    it { is_expected.to install_package(%w(perl-DBD-Pg postgresql)) }
+    it { is_expected.to_not include_recipe('osl-mysql::client') }
+
+    # RT is pointed at the Postgres backend.
+    it { is_expected.to render_file('/opt/rt/etc/RT_SiteConfig.pm').with_content("Set($DatabaseType, 'Pg');") }
+
+    # Root password is set via psql on a fresh init.
+    it do
+      resource = chef_run.execute('Set root password')
+      expect(resource.action).to eq([:nothing])
+      expect(resource.sensitive).to be true
+      expect(resource.command).to eq(<<~EOC)
+        PGPASSWORD='rt-password' psql -h localhost \
+          -U rt-user \
+          -c "UPDATE Users SET Password=md5('my-epic-rt') WHERE Name='root';" \
+          rt
+      EOC
+    end
+  end
 end

--- a/test/cookbooks/osl-rt-test/recipes/osl_request_tracker_postgresql.rb
+++ b/test/cookbooks/osl-rt-test/recipes/osl_request_tracker_postgresql.rb
@@ -1,0 +1,37 @@
+# PostgreSQL suite: same as the standard suite but backed by Postgres. Uses its
+# own data bag (db.type = Pg) so it is self-contained alongside the MySQL suite.
+node.default['osl-rt']['data-bag'] = 'postgresql'
+
+# Download mailx/s-nail for testing the email queue later
+if node['platform_version'].to_i <= 8
+  package %w(mailx jq)
+else
+  package %w(s-nail jq)
+end
+
+# Database. osl_postgresql_test stands up Postgres locally and creates the rt
+# database/role; the role is a superuser so rt-setup-database can load the schema.
+osl_postgresql_test 'rt' do
+  username 'rt-user'
+  password 'rt-password'
+end
+
+# Request Tracker
+include_recipe 'osl-rt'
+
+# Exercise the RT_SiteConfig.d drop-in, same as the MySQL suite.
+file '/opt/rt/etc/RT_SiteConfig.d/99-dropin-test.pm' do
+  content "Set($Timezone, 'US/Pacific');\n1;\n"
+  group 'apache'
+  mode '0640'
+end
+
+# Restart Apache, removing race condition
+# The website is already "deployed", but there is a race condition of the site being up in time
+# and our test sending in a support ticket.
+service 'httpd' do
+  action :restart
+  not_if { ::File.exist?('/root/first_run_done') }
+end
+
+file '/root/first_run_done'

--- a/test/integration/data_bags/request-tracker/postgresql.json
+++ b/test/integration/data_bags/request-tracker/postgresql.json
@@ -1,0 +1,104 @@
+{
+  "db": {
+    "type": "Pg",
+    "host": "localhost",
+    "name": "rt"
+  },
+  "db-username": "rt-user",
+  "db-password": "rt-password",
+  "root-password": "my-epic-rt",
+  "user": "support",
+  "queues": {
+    "Support": "support",
+    "Frontend Team": "frontend",
+    "Backend Team": "backend",
+    "DevOps Team": "devops",
+    "Marketing Team": "advertising",
+    "The Board Of Directors": "board"
+  },
+  "plugins": [
+    "RT::Extension::REST2",
+    "RT::Authen::Token"
+  ],
+  "lifecycles": {
+    "default": {
+      "initial": [
+        "new"
+      ],
+      "active": [
+        "open"
+      ],
+      "inactive": [
+        "stalled",
+        "resolved",
+        "rejected",
+        "deleted"
+      ],
+      "defaults": {
+        "on_create": "new",
+        "on_merge": "resolved",
+        "approved": "open",
+        "denied": "rejected"
+      },
+      "transitions": {
+        "": [
+          "new",
+          "open",
+          "resolved"
+        ],
+        "new": [
+          "open",
+          "stalled",
+          "resolved",
+          "rejected",
+          "deleted"
+        ],
+        "open": [
+          "new",
+          "stalled",
+          "resolved",
+          "rejected",
+          "deleted"
+        ],
+        "stalled": [
+          "new",
+          "open",
+          "rejected",
+          "resolved",
+          "deleted"
+        ],
+        "resolved": [
+          "new",
+          "open",
+          "stalled",
+          "rejected",
+          "deleted"
+        ],
+        "rejected": [
+          "new",
+          "open",
+          "stalled",
+          "resolved",
+          "deleted"
+        ],
+        "deleted": [
+          "new",
+          "open",
+          "stalled",
+          "rejected",
+          "resolved"
+        ]
+      },
+      "rights": {
+        "* -> deleted": "DeleteTicket",
+        "* -> *": "ModifyTicket"
+      },
+      "actions": {
+        "new -> open": {
+          "label": "Open It",
+          "update": "Respond"
+        }
+      }
+    }
+  }
+}

--- a/test/integration/postgresql/postgresql_test.rb
+++ b/test/integration/postgresql/postgresql_test.rb
@@ -1,0 +1,105 @@
+describe service 'httpd' do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe service('postfix') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+%w(
+  mutt
+  procmail
+  request-tracker
+  perl-DBD-Pg
+).each do |p|
+  describe package p do
+    it { should be_installed }
+  end
+end
+
+# RT talks to PostgreSQL, listening on 5432 alongside the web/mail ports.
+%w(
+  25
+  80
+  5432
+).each do |p|
+  describe port p do
+    it { should be_listening }
+  end
+end
+
+# RT major version via the package (the login page no longer carries it on RT 5).
+describe package('request-tracker') do
+  if os[:release].to_i >= 10
+    its('version') { should match(/^5\./) }
+  else
+    its('version') { should match(/^4\.4/) }
+  end
+end
+
+# The site config points RT at the Postgres backend.
+describe file '/opt/rt/etc/RT_SiteConfig.pm' do
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'apache' }
+  its('mode') { should cmp '0640' }
+  [
+    "Set($DatabaseType, 'Pg');",
+    "Set($DatabaseHost, 'localhost');",
+    "Set($DatabaseRTHost, 'localhost');",
+    "Set($DatabaseName, 'rt');",
+    "Set($DatabaseUser, 'rt-user');",
+    "Set($DatabasePassword, 'rt-password');",
+    'Set($SetOutgoingMailFrom, 1);',
+  ].each do |line|
+    its('content') { should match Regexp.escape line }
+  end
+end
+
+# RT's schema was loaded into Postgres, so the Users table exists.
+describe command "PGPASSWORD=rt-password psql -h localhost -U rt-user -tAc \"SELECT to_regclass('users')\" rt" do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match(/users/) }
+end
+
+describe command '/usr/local/sbin/rt help' do
+  its('exit_status') { should eq 0 }
+end
+
+# Send a test ticket
+describe command 'echo "Hello, I need help creating a Request Tracker instance" | mailx -r root@localhost -s "support-test" support@example.org' do
+  its('exit_status') { should eq 0 }
+end
+
+describe command 'HOSTALIASES=/root/.rthost /opt/rt/bin/rt ls -t queue -f Name' do
+  its('exit_status') { should eq 0 }
+  [
+    'Frontend Team',
+    'Backend Team',
+    'DevOps Team',
+    'Marketing Team',
+    'The Board Of Directors',
+    'Support',
+  ].each do |line|
+    its('stdout') { should match line }
+  end
+end
+
+describe command 'HOSTALIASES=/root/.rthost /opt/rt/bin/rt ls -t ticket -f Subject,Requestors,Queue' do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /^1\s+Support\s+support-test\s+root@localhost$/ }
+end
+
+# REST login with the root password set during init proves the md5() password
+# update ran against Postgres and RT authenticates against the Pg backend.
+describe command "HOSTALIASES=/root/.rthost curl -sk -u 'root:my-epic-rt' http://rtlocal/REST/2.0/ticket/1 | jq .Subject" do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match /^"support-test"$/ }
+end
+
+# RT_SiteConfig.d drop-in is loaded by RT's own config loader.
+describe command %q{perl -I/opt/rt/lib -e 'use RT; RT::LoadConfig(); print RT->Config->Get("Timezone")'} do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should cmp 'US/Pacific' }
+end


### PR DESCRIPTION
- Allow RT to run against PostgreSQL by setting the data bag `db.type` to `Pg`
- Install the `perl-DBD-Pg` driver and `psql` client (instead of the MariaDB
  client) when Postgres is configured
- Dispatch the one-time DB guards and root-password set to `psql` for Postgres
- Add an `osl_postgresql_test`-backed `postgresql` Test Kitchen suite (recipe,
  data bag, and inspec)
- Add a PostgreSQL unit-spec context

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
