### PR TITLE
Add web-port / web-base-url data bag options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Name             | Type   | Description                                         
 `root-password`  | String | The password used for the root account on RT                 | nil
 `fqdn`           | String | The FQDN of the site (web/host domain)                       | `example.org`
 `mail-domain`    | String | The public email domain for queue addresses, when it differs from the host `fqdn` (e.g. `example.org` while the site is `support.example.org`). Mail to either domain is accepted. | `fqdn`
+`web-port`       | Integer| Sets RT's `$WebPort`. Needed when TLS terminates upstream (e.g. HAProxy) and RT serves plain HTTP: set `443` so RT treats itself as HTTPS, otherwise it assumes `http://<fqdn>:80` and rejects HTTPS form posts with a "possible cross-site request forgery" error. | RT default (`80`)
+`web-base-url`   | String | Sets RT's `$WebBaseURL` explicitly. Only needed when the public URL isn't derivable from `fqdn` + `web-port` (a different public host, a `WebPath` prefix, etc.); otherwise RT derives it. | derived
 `user`           | String | The user account that is responsible for being the default email | `support`
 `failed-email`   | String | Address that mail RT fails to process is forwarded to        | `root`
 `forward-email`  | String | If set, a copy of incoming queue mail is forwarded off-box to this address (e.g. a Google Workspace archive mailbox). | nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,6 +44,14 @@ module OslRT
         config_options = {}
         config_options['$rtname'] = rt_config['fqdn']
         config_options['$WebDomain'] = rt_config['fqdn']
+        # When TLS terminates upstream (HAProxy) and RT serves plain HTTP, RT
+        # otherwise assumes http://<fqdn>:80 and rejects HTTPS form posts with a
+        # "possible cross-site request forgery" error (the browser Referer is :443).
+        # 'web-port' (e.g. 443) makes RT treat itself as HTTPS; 'web-base-url'
+        # overrides the full base URL when the public URL isn't derivable from the
+        # fqdn + port (different host, a WebPath prefix, etc.).
+        config_options['$WebPort'] = rt_config['web-port'] if rt_config['web-port']
+        config_options['$WebBaseURL'] = rt_config['web-base-url'] if rt_config['web-base-url']
         config_options['$Organization'] = mail_domain
         config_options['$CorrespondAddress'] = "#{rt_config['user']}@#{mail_domain}"
         config_options['$CommentAddress'] = "#{rt_config['user']}-comment@#{mail_domain}"

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -141,6 +141,9 @@ describe 'osl-rt::default' do
       # bounces don't dead-end at the local apache/root mailbox.
       it { is_expected.to render_file('/opt/rt/etc/RT_SiteConfig.pm').with_content('Set($SetOutgoingMailFrom, 1);') }
 
+      # No web-port/web-base-url in this data bag -> RT keeps its own defaults.
+      it { is_expected.to_not render_file('/opt/rt/etc/RT_SiteConfig.pm').with_content('Set($WebPort,') }
+
       # REST2/Authen::Token are plugins on RT 4.4 (EL8/9) but core on RT 5 (EL10+).
       if p[:version].to_i >= 10
         it { is_expected.to_not render_file('/opt/rt/etc/RT_SiteConfig.pm').with_content("Plugin('RT::Extension::REST2');") }
@@ -442,6 +445,39 @@ describe 'osl-rt::default' do
 
   # RT user not among queue emails: still self-aliased so its mailbox gets mail
   # (overrides the system "support: postmaster" default).
+  context 'with a web port and base url' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(ALMA_9) do |node|
+        node.default['osl-rt']['data-bag'] = 'default'
+      end.converge(described_recipe)
+    end
+
+    before do
+      stub_command('/usr/bin/test /etc/alternatives/mta -ef /usr/sbin/sendmail.postfix').and_return(true)
+      stub_command(/SHOW TABLES LIKE 'Users'/).and_return(false)
+      stub_command(/SELECT 1 FROM Queues WHERE Name=/).and_return(false)
+      stub_data_bag_item('request-tracker', 'default').and_return({
+                                                                    'db-username': 'rt-user',
+                                                                    'db-password': 'rt-password',
+                                                                    'root-password': 'my-epic-rt',
+                                                                    'user': 'support',
+                                                                    'web-port': 443,
+                                                                    'web-base-url': 'https://support.example.org',
+                                                                    'queues': {
+                                                                      'Support': 'support',
+                                                                    },
+                                                                  })
+    end
+
+    # Behind a TLS-terminating proxy: tell RT its real scheme/port so the CSRF
+    # Referer check passes.
+    it do
+      is_expected.to render_file('/opt/rt/etc/RT_SiteConfig.pm')
+        .with_content('Set($WebPort, 443);')
+        .with_content("Set($WebBaseURL, 'https://support.example.org');")
+    end
+  end
+
   context 'with the RT user not among the queue emails' do
     cached(:chef_run) do
       ChefSpec::SoloRunner.new(ALMA_9) do |node|


### PR DESCRIPTION
- set RT's $WebPort / $WebBaseURL from the data bag, for instances behind a
  TLS-terminating proxy (HAProxy) where RT serves plain HTTP; otherwise RT
  assumes http://<fqdn>:80 and rejects HTTPS form posts as CSRF
- both optional; default behavior unchanged

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
